### PR TITLE
Changed API rate to 15 seconds

### DIFF
--- a/producer.py
+++ b/producer.py
@@ -47,5 +47,5 @@ while True:
     
     end_time = time.time()
     time_interval = end_time - start_time
-    # setting the API to be queried every 5 minutes
-    time.sleep(300 - time_interval)
+    # setting the API to be queried every 15 seconds
+    time.sleep(15 - time_interval)


### PR DESCRIPTION
I think with the original 5 minutes it could give the impression something was not working. Changed it to 15 seconds so developers going over the tutorial can see things are moving. This is in agreement with a pull request I proposed for the questdb tutorial.